### PR TITLE
fixes #77: Ensure list cloning duplicates an entire list and not just the first 10 items

### DIFF
--- a/api/src/movielist/movielist.service.ts
+++ b/api/src/movielist/movielist.service.ts
@@ -18,16 +18,28 @@ export class MovielistService {
   }
 
   async cloneList(listId: string, userId: string, name?: string) {
+    const { count } = await this.movieService.getMovies({
+      per_page: 0,
+      page_number: 0,
+      listId,
+    });
     const originalList = await this.listService.getList(listId);
-    const { movies } = await this.movieService.getMovies({ listId });
-
-    const clonedList = await this.createListWithMovies(
-      {
-        name: name || originalList.name,
-        movie: movies,
-      },
+    const clonedList = await this.listService.createList(
+      name || originalList.name,
       userId,
     );
+
+    if (count === 0) {
+      return clonedList;
+    }
+
+    const { movies } = await this.movieService.getMovies({
+      per_page: count,
+      page_number: 0,
+      listId,
+    });
+
+    await this.movieService.createMovies(movies, clonedList.id);
 
     return clonedList;
   }


### PR DESCRIPTION
## Issue
closes #77 

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR ensures that when cloning a list we clone the entire list and not just the first ten items (as per the default pagination.)

It does so in batches of 10, each time grabbing 10 movies from the list and inserting the "slice" of 10 movies into an array of promises which is ran after all movies have been inserted into the array.

## Testing the PR
Create a long list (via `create a list w/ movies 3`?) and run the clone endpoint using the new `listId`, returned from the long list. A new list should be returned containing all movies and not just the first 10.

## Checklist
<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
