### PR TITLE
Fix: remove count prop from payload in pagination middleware

### DIFF
--- a/api/src/middleware/pagination.ts
+++ b/api/src/middleware/pagination.ts
@@ -1,22 +1,19 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { PER_PAGE, PAGE_NUMBER } from '../utils';
 
 @Injectable()
 export class PaginationMiddleware implements NestMiddleware {
   async use(req: Request, res: Response, next: () => void) {
-    if (!req.query.per_page || !req.query.page_number) {
-      return next();
-    }
-
-    const perPageStr = req.query.per_page?.toString();
-    const pageNumberStr = req.query.page_number?.toString();
-
-    const per_page = parseInt(perPageStr, 10);
-    const page_number = parseInt(pageNumberStr, 10);
-
     const parsedQuery = {
-      per_page,
-      page_number,
+      per_page: parseInt(
+        req.query.per_page?.toString() || PER_PAGE.toString(),
+        10,
+      ),
+      page_number: parseInt(
+        req.query.page_number?.toString() || PAGE_NUMBER.toString(),
+        10,
+      ),
     };
 
     const originalSend: <T>(body: T) => Response = res.send;
@@ -44,12 +41,9 @@ export class PaginationMiddleware implements NestMiddleware {
 }
 
 const calculatePaginationInfo = (
-  query: { per_page: number; page_number: number },
+  { per_page, page_number }: { per_page: number; page_number: number },
   count: number,
 ) => {
-  const per_page = query.per_page || 10;
-  const page_number = query.page_number || 0;
-
   const last_page = Math.floor((count > 0 ? count - 1 : 0) / per_page);
   const current_page = page_number > last_page ? last_page : page_number;
   const prev_page = current_page > 0 ? current_page - 1 : 0;

--- a/api/src/utils/constants.ts
+++ b/api/src/utils/constants.ts
@@ -1,0 +1,2 @@
+export const PER_PAGE = 10;
+export const PAGE_NUMBER = 0;

--- a/api/src/utils/index.ts
+++ b/api/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './logLevels';
+export * from './constants';


### PR DESCRIPTION
## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR adds and uses the new constants file when making a request to /movies, /lists, and /users.

## Testing the PR
When running the above routes assert that _not_ including per_page and page_number in the query returns the default values (10 and 0 respectively)

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
